### PR TITLE
fix issue #44

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -6,6 +6,7 @@ import {
   onUnmounted,
   provide,
   ref,
+  watch
 } from 'vue'
 
 import { useRoute } from 'vue-router'
@@ -103,18 +104,23 @@ onMounted(() => {
   refreshNoticeNum()
   updateChatNum(undefined)
   window.addEventListener('resize', updateWidth)
-  if (!isPC.value) {
-    window.addEventListener('touchstart', handleTouchStart)
-    window.addEventListener('touchend', handleTouchEnd)
-  }
 })
+
 onUnmounted(() => {
   window.removeEventListener('resize', updateWidth)
-  if (!isPC.value) {
+  window.removeEventListener('touchstart', handleTouchStart)
+  window.removeEventListener('touchend', handleTouchEnd)
+})
+
+watch(isPC, (value) => {
+  if (!value) {
+    window.addEventListener('touchstart', handleTouchStart)
+    window.addEventListener('touchend', handleTouchEnd)
+  } else {
     window.removeEventListener('touchstart', handleTouchStart)
     window.removeEventListener('touchend', handleTouchEnd)
   }
-})
+}, { immediate: true })
 </script>
 
 <template>


### PR DESCRIPTION
isPC 是响应式的，只在 onMounted 和 onUnmounted 的时机做了一次性判断会导致如果用户在运行中从移动端切换到 PC，事件监听不会自动更新。使用 watch 动态监听 isPC解决该问题。